### PR TITLE
handle the case of playback while trakt is down

### DIFF
--- a/default.py
+++ b/default.py
@@ -937,6 +937,12 @@ def play_source(mode, hoster_url, video_type, slug, season='', episode=''):
             path = make_path(path, video_type, item['title'], item['year'])
             file_name = utils.filename_from_title(item['title'], video_type, item['year'])
     except TransientTraktError as e:
+    
+        if video_type == VIDEO_TYPES.EPISODE:
+            show_meta = {}
+            show_meta['title'] = ""
+            show_meta['year'] = ""
+        
         log_utils.log('During Playback: %s' % (str(e)), xbmc.LOGWARNING) # just log warning if trakt calls fail and leave meta and art blank
     
     if mode in [MODES.DOWNLOAD_SOURCE, MODES.DIRECT_DOWNLOAD]:


### PR DESCRIPTION
If the TV Episode is added to the library, trakt is down and subtitles are enabled the trakt error would stop the play with the below error. This code change tries to initialize the variables so that the show can still be watched while trakt is down - possibly without proper subtitles but the subtitles might be able to be pulled using Subtitles functionality from KODI.

23:07:08 T:140155050522368 WARNING: Stream All The Sources: During Playback: Temporary Trakt Error: HTTP Error 502: Bad Gateway
23:07:08 T:140155050522368   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.UnboundLocalError'>
                                            Error Contents: local variable 'show_meta' referenced before assignment
                                            Traceback (most recent call last):
                                              File "/storage/.kodi/addons/plugin.video.salts/default.py", line 1875, in <module>
                                                sys.exit(main())
                                              File "/storage/.kodi/addons/plugin.video.salts/default.py", line 1868, in main
                                                url_dispatcher.dispatch(mode, _SALTS.queries)
                                              File "/storage/.kodi/addons/plugin.video.salts/salts_lib/url_dispatcher.py", line 81, in dispatch
                                                self.func_registry[mode](*args, **kwargs)
                                              File "/storage/.kodi/addons/plugin.video.salts/default.py", line 812, in get_sources
                                                return play_source(mode, stream_url, video_type, slug, season, episode)
                                              File "/storage/.kodi/addons/plugin.video.salts/default.py", line 942, in play_source
                                                srt_path = download_subtitles(_SALTS.get_setting('subtitle-lang'), show_meta['title'], show_meta['year'], season, episode)
                                            UnboundLocalError: local variable 'show_meta' referenced before assignment
                                            -->End of Python script error report<--
23:07:08 T:140156175656832   ERROR: Playlist Player: skipping unplayable item: 0, path [plugin://plugin.video.salts/?episode=2&title=Bering+Sea+Gold%3A+Under+the+Ice&ep_title=Smoke+Under+Ice+&season=1&video_type=Episode&mode=get_sources&dialog=True&year=2012&slug=bering-sea-gold-under-the-ice]