### PR TITLE
Library nfo files / Logging

### DIFF
--- a/default.py
+++ b/default.py
@@ -1718,9 +1718,9 @@ def add_to_library(video_type, title, year, trakt_id):
         save_path = kodi.get_setting('movie-folder')
         save_path = xbmc.translatePath(save_path)
         if create_nfo > 0:
-            movie = trakt_api.get_movie_details(trakt_id)
             movie_path = make_path(save_path, video_type, title, year)
-            if ((create_nfo == 1) and (movie['title'] not in movie_path)) or create_nfo == 2:
+            if ((create_nfo == 1) and (title not in movie_path)) or create_nfo == 2:
+                movie = trakt_api.get_movie_details(trakt_id)
                 write_nfo(movie_path, video_type, movie['ids'])
         strm_string = kodi.get_plugin_url({'mode': MODES.GET_SOURCES, 'video_type': video_type, 'title': title, 'year': year, 'trakt_id': trakt_id, 'dialog': True})
         filename = utils.filename_from_title(title, VIDEO_TYPES.MOVIE, year)

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -1514,3 +1514,7 @@ msgstr ""
 msgctxt "#30648"
 msgid "Show Custom Progress Dialog from Library"
 msgstr ""
+
+msgctxt "#30649"
+msgid "Create nfo for shows/movies with metadata ids?"
+msgstr ""

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -1516,5 +1516,13 @@ msgid "Show Custom Progress Dialog from Library"
 msgstr ""
 
 msgctxt "#30649"
-msgid "Create nfo for shows/movies with metadata ids?"
+msgid "Create tvshow/movie nfo file for?"
+msgstr ""
+
+msgctxt "#30650"
+msgid "Won't scrape"
+msgstr ""
+
+msgctxt "#30651"
+msgid "All"
 msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -84,6 +84,7 @@
         <setting id="update_subs-notify" type="bool" label="30568" default="false" visible="true"/>
         <setting id="include_movies" type="bool" label="30569" default="false" visible="true"/>
         <setting id="cleanup-subscriptions" type="bool" label="30570" default="false" visible="true"/>
+        <setting id="create_nfo_for_all" type="bool" label="30649" default="false" visible="true"/>
         <setting id="exists_list" type="text" visible="false"/>
     </category>
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -84,7 +84,7 @@
         <setting id="update_subs-notify" type="bool" label="30568" default="false" visible="true"/>
         <setting id="include_movies" type="bool" label="30569" default="false" visible="true"/>
         <setting id="cleanup-subscriptions" type="bool" label="30570" default="false" visible="true"/>
-        <setting id="create_nfo_for_all" type="bool" label="30649" default="false" visible="true"/>
+        <setting id="create_nfo" type="enum" label="30649" lvalues="30604|30650|30651" default="0" visible="true"/>
         <setting id="exists_list" type="text" visible="false"/>
     </category>
 


### PR DESCRIPTION
tvshow.nfo/movie.nfo containing tvdb/tmdb/imdb urls for library scrapers

- create nfo files in all cases where title is changed in path for certain characters and metadata ids are available (Default)
- add setting to enable creating the nfo file for all shows/movies that have metadata ids available

tvshow url = tvdb -> tmdb -> imdb
movie url = tmdb -> imdb

Fixed logging args -- line 1733/1794
Changed strm creation logging from notice to debug, multi-season shows this can cause performance loss on rpi, droid devices with slower disk media