### PR TITLE
fix _http_get for noobroom

### DIFF
--- a/scrapers/noobroom_scraper.py
+++ b/scrapers/noobroom_scraper.py
@@ -145,7 +145,7 @@ class NoobRoom_Scraper(scraper.Scraper):
         settings.append('         <setting id="%s-include_premium" type="bool" label="     %s" default="false" visible="eq(-8,true)"/>' % (name, i18n('include_premium')))
         return settings
 
-    def _http_get(self, url, data=None, cache_limit=8):
+    def _http_get(self, url, data=None, cache_limit=8, headers=None):
         # return all uncached blank pages if no user or pass
         if not self.username or not self.password:
             return ''


### PR DESCRIPTION
Fixes:
````
ERROR: Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/home/osmc/.kodi/addons/plugin.video.salts/salts_lib/utils.py", line 416, in parallel_get_sources
    hosters = scraper.get_sources(video)
  File "/home/osmc/.kodi/addons/plugin.video.salts/scrapers/noobroom_scraper.py", line 72, in get_sources
    source_url = self.get_url(video)
  File "/home/osmc/.kodi/addons/plugin.video.salts/scrapers/noobroom_scraper.py", line 108, in get_url
    return super(NoobRoom_Scraper, self)._default_get_url(video)
  File "/home/osmc/.kodi/addons/plugin.video.salts/scrapers/scraper.py", line 233, in _default_get_url
    url = self._get_episode_url(show_url, video)
  File "/home/osmc/.kodi/addons/plugin.video.salts/scrapers/noobroom_scraper.py", line 114, in _get_episode_url
    return super(NoobRoom_Scraper, self)._default_get_episode_url(show_url, video, episode_pattern, title_pattern, airdate_pattern)
  File "/home/osmc/.kodi/addons/plugin.video.salts/scrapers/scraper.py", line 378, in _default_get_episode_url
    html = self._http_get(url, data=data, headers=headers, cache_limit=2)
TypeError: _http_get() got an unexpected keyword argument 'headers'
````
I guess this bug was introduced with:
https://github.com/tknorris/salts/commit/0a49d84d9ace20a00e492d5be5395200302806be#diff-408da22c800b4f1c060771d7e6ec3460L378

Might as well apply to other scrapers.